### PR TITLE
Optimize the code and avoid the check of bound.

### DIFF
--- a/HNParsePage.py
+++ b/HNParsePage.py
@@ -5,7 +5,7 @@
 import struct
 
 class HNParsePage(object):
-    def __init__(self, data, old_style=False):
+    def __init__(self, data, nfigure, old_style=False):
         self.data = data
         self.data_length = len(data)
         self.characters = []
@@ -52,9 +52,7 @@ class HNParsePage(object):
                 self.offset += 4
 
         def Figure(self, code):
-            try:
-                self.data[self.offset+25]
-            except IndexError: # short data, nothing to do
+            if len(self.figures) == nfigure:
                 return
             (ignore1, offset_x, offset_y, size_x, size_y, int2, int3, int4, int5)= struct.unpack("<HHHHHIIII", self.data[self.offset:self.offset+26])
             # in units of 1/2.473 pixels

--- a/cajparser.py
+++ b/cajparser.py
@@ -319,16 +319,11 @@ class CAJParser(object):
                 output = caj.read(size_of_text_section)
             from HNParsePage import HNParsePage
             page_style = (next_page_data_offset > page_data_offset)
-            page_data = HNParsePage(output, page_style)
+            page_data = HNParsePage(output, images_per_page, page_style)
 
             if (images_per_page > 1):
-                if (len(page_data.figures) == images_per_page):
-                    image_list.append(None)
-                    image_list.append(page_data.figures)
-                else:
-                    print("Page %d, Image Count %d != %d" % (i+1, len(page_data.figures), images_per_page))
-                    image_list.append(None)
-                    image_list.append(page_data.figures[0:images_per_page])
+                image_list.append(None)
+                image_list.append(page_data.figures)
             current_offset = page_data_offset + size_of_text_section
             for j in range(images_per_page):
                 caj.seek(current_offset)
@@ -444,7 +439,7 @@ class CAJParser(object):
                 output = caj.read(size_of_text_section)
             from HNParsePage import HNParsePage
             page_style = (next_page_data_offset > page_data_offset)
-            page_data = HNParsePage(output, page_style)
+            page_data = HNParsePage(output, images_per_page, page_style)
             print("Text on Page %d:" % (i+1))
             print(page_data.texts)
             #print("Figures:\n", page_data.figures)
@@ -489,7 +484,7 @@ class CAJParser(object):
                 print("Page Text Header non-COMPRESSTEXT:\n", self.dump(output, GB=True), sep="")
             from HNParsePage import HNParsePage
             page_style = (next_page_data_offset > page_data_offset)
-            page_data = HNParsePage(output, page_style)
+            page_data = HNParsePage(output, images_per_page, page_style)
             print("Text:\n", page_data.texts)
             print("Figures:\n", page_data.figures)
             current_offset = page_data_offset + size_of_text_section


### PR DESCRIPTION
Pass images_per_page into HNParsePage will be better, and thus the bound-checking of data can be avoided.