### PR TITLE
修复指定color-space时存在的错误，并兼容一个非常旧的hn格式

### DIFF
--- a/HNParsePage.py
+++ b/HNParsePage.py
@@ -46,7 +46,10 @@ class HNParsePage(object):
             if (code == 0x8001):
                 self.characters.append("\n")
             while (1):
-                if (self.data[self.offset+1] == 0x80):
+                try:
+                    if (self.data[self.offset+1] == 0x80):
+                        break
+                except IndexError:
                     break
                 self.characters.append(bytes([self.data[self.offset+3],self.data[self.offset+2]]).decode("gbk"))
                 self.offset += 4

--- a/cajparser.py
+++ b/cajparser.py
@@ -397,8 +397,14 @@ class CAJParser(object):
                     if (image_type_enum == 1):
                         # non-inverted JPEG Images
                         height = -height
+
+                    from PIL import Image as pilimage
+                    with open(".tmp.jpg", "wb") as f:
+                        f.write(image_data)
+                    pim = pilimage.open(".tmp.jpg")
+
                     image_item = (
-                        Colorspace.RGB,
+                        Colorspace[pim.mode],
                         (300, 300),
                         ImageFormat.JPEG,
                         image_data,
@@ -409,6 +415,7 @@ class CAJParser(object):
                         8,
                         0
                     )
+                    os.remove(".tmp.jpg")
                 else:
                     raise SystemExit("Unknown Image Type %d" % (image_type_enum))
                 image_list.append(image_item)

--- a/pdfwutils.py
+++ b/pdfwutils.py
@@ -1078,7 +1078,29 @@ class pdfdoc(object):
                 image1[PdfName.Height] = -Im_i['imgheightpx']
             else:
                 image1[PdfName.Height] = Im_i['imgheightpx']
-            image1[PdfName.ColorSpace] = PdfName.DeviceRGB
+
+            if Im_i['color'] == Colorspace["1"] or Im_i['color'] == Colorspace.L:
+                image1[PdfName.ColorSpace] = PdfName.DeviceGray
+            elif Im_i['color'] == Colorspace.RGB:
+                image1[PdfName.ColorSpace] = PdfName.DeviceRGB
+            elif Im_i['color'] == Colorspace.CMYK or Im_i['color'] == Colorspace["CMYK;I"]:
+                image1[PdfName.ColorSpace] = PdfName.DeviceCMYK
+            elif Im_i['color'] == Colorspace.P:
+                if self.with_pdfrw:
+                    raise Exception(
+                        "pdfrw does not support hex strings for "
+                        "palette image input, re-run with "
+                        "--without-pdfrw"
+                    )
+                image1[PdfName.ColorSpace] = [
+                    PdfName.Indexed,
+                    PdfName.DeviceRGB,
+                    len(palette) - 1,
+                    PdfString.encode(palette, hextype=True),
+                ]
+            else:
+                raise UnsupportedColorspaceError("unsupported color space: %s" % Im_i['color'].name)
+
             image1[PdfName.BitsPerComponent] = Im_i['depth']
 
             offset_x = coordinates[i][0] / 300 * 72 / 2.473


### PR DESCRIPTION
1，jpeg文件的color-space不止有RGB，还存在别的可能，修复后CAJSamples里面有多个文件的转换效果会更好；
2，存在一个旧版的hn格式，其“COMPRESSTEXT”字段在text_header_read32中的位置为从0开始；
3，知网的某位前辈可能故意引进了一个BUG，从文件中读出的images_per_page字段事实上为平方后的结果；
4，样本文件为[碳_碳复合材料多重环境下的氧化机理研究_李龙.zip](https://github.com/caj2pdf/caj2pdf/files/7573979/_._.zip)。
