### PR TITLE
use absolute path to load libraries, to make the application work cor…

### DIFF
--- a/jbig2dec.py
+++ b/jbig2dec.py
@@ -18,13 +18,14 @@ import struct
 import platform
 
 arch = platform.architecture()
+script_path = os.path.dirname(os.path.realpath(__file__))
 if (arch[1] == 'WindowsPE'):
     if (arch[0] == '64bit'):
-        libjbig2codec = cdll.LoadLibrary("./lib/bin/libjbig2codec-w64.dll")
+        libjbig2codec = cdll.LoadLibrary(script_path + "/lib/bin/libjbig2codec-w64.dll")
     else:
-        libjbig2codec = cdll.LoadLibrary("./lib/bin/libjbig2codec-w32.dll")
+        libjbig2codec = cdll.LoadLibrary(script_path + "/lib/bin/libjbig2codec-w32.dll")
 else:
-    libjbig2codec = cdll.LoadLibrary("./libjbig2codec.so")
+    libjbig2codec = cdll.LoadLibrary(script_path + "/lib/libjbig2codec.so")
 
 decode_jbig2data_c    = libjbig2codec.decode_jbig2data_c
 

--- a/jbigdec.py
+++ b/jbigdec.py
@@ -20,13 +20,14 @@ import struct
 import platform
 
 arch = platform.architecture()
+script_path = os.path.dirname(os.path.realpath(__file__))
 if (arch[1] == 'WindowsPE'):
     if (arch[0] == '64bit'):
-        libjbigdec = cdll.LoadLibrary("./lib/bin/libjbigdec-w64.dll")
+        libjbigdec = cdll.LoadLibrary(script_path + "/lib/bin/libjbigdec-w64.dll")
     else:
-        libjbigdec = cdll.LoadLibrary("./lib/bin/libjbigdec-w32.dll")
+        libjbigdec = cdll.LoadLibrary(script_path + "/lib/bin/libjbigdec-w32.dll")
 else:
-    libjbigdec = cdll.LoadLibrary("./libjbigdec.so")
+    libjbigdec = cdll.LoadLibrary(script_path + "/lib/libjbigdec.so")
 
 #SaveJbigAsBmp = libjbigdec.SaveJbigAsBmp
 #SaveJbigAsBmp.restype = None


### PR DESCRIPTION
use absolute path to load libraries, to make the application work correctly when call it from a different path