### PR TITLE
Patch for newer version of PyPDF2

### DIFF
--- a/cajparser.py
+++ b/cajparser.py
@@ -4,7 +4,7 @@ from shutil import copy
 from subprocess import check_output, STDOUT, CalledProcessError
 from utils import fnd, fnd_all, add_outlines, fnd_rvrs, fnd_unuse_no
 
-from PyPDF2 import utils as utils
+from PyPDF2 import errors
 
 KDH_PASSPHRASE = b"FZHMEI"
 
@@ -294,8 +294,8 @@ class CAJParser(object):
         # Add Outlines
         try:
             add_outlines(self.get_toc(), "pdf_toc.pdf", dest)
-        except utils.PdfReadError as e:
-            print("utils.PdfReadError:", str(e))
+        except errors.PdfReadError as e:
+            print("errors.PdfReadError:", str(e))
             copy("pdf_toc.pdf", dest)
             pass
         os.remove("pdf.tmp")

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,6 @@
 import os
 import sys
-import PyPDF2.pdf as PDF
+import PyPDF2.generic as PDF
 from PyPDF2 import PdfFileWriter, PdfFileReader
 
 
@@ -149,7 +149,7 @@ def fnd_unuse_no(nos1, nos2):
 
 def make_dest(pdfw, pg):
     d = PDF.ArrayObject()
-    d.append(pdfw.getPage(pg).indirectRef)
+    d.append(pdfw.getPage(pg).indirect_ref)
     d.append(PDF.NameObject("/XYZ"))
     d.append(PDF.NullObject())
     d.append(PDF.NullObject())
@@ -217,9 +217,9 @@ def add_outlines(toc, filename, output):
                     PDF.NameObject(v): idorefs[n.index]
                 })
         olitems.append(oli)
-    pdf_out._addObject(ol)
+    pdf_out._add_object(ol)
     for i in olitems:
-        pdf_out._addObject(i)
+        pdf_out._add_object(i)
     pdf_out._root_object.update({
         PDF.NameObject("/Outlines"): idorefs[0]
     })

--- a/utils.py
+++ b/utils.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import PyPDF2.generic as PDF
-from PyPDF2 import PdfFileWriter, PdfFileReader
+from PyPDF2 import PdfWriter, PdfReader
 
 
 class Node(object):
@@ -183,7 +183,7 @@ def add_outlines(toc, filename, output):
     inputFile = open(filename, 'rb')
     pdf_in = PdfFileReader(inputFile)
     for p in pdf_in.pages:
-        pdf_out.addPage(p)
+        pdf_out.add_page(p)
     toc_num = len(toc)
     if (toc_num == 0): # Just copy if toc empty
         outputFile = open(output, "wb")


### PR DESCRIPTION
PyPDF2 has updated its naming rules since version 1.28.0
This is the patch to support the update. 
Please note that this patch is NOT compatible with PyPDF2 version before 1.28.0