### PR TITLE
fix: load library file based on root directory

### DIFF
--- a/jbig2dec.py
+++ b/jbig2dec.py
@@ -13,18 +13,20 @@
 
 
 from ctypes import *
+import os
 import struct
 
 import platform
 
 arch = platform.architecture()
+baseDir = os.path.dirname(__file__)
 if (arch[1] == 'WindowsPE'):
     if (arch[0] == '64bit'):
-        libjbig2codec = cdll.LoadLibrary("./lib/bin/libjbig2codec-w64.dll")
+        libjbig2codec = cdll.LoadLibrary(os.path.join(baseDir, "./lib/bin/libjbig2codec-w64.dll"))
     else:
-        libjbig2codec = cdll.LoadLibrary("./lib/bin/libjbig2codec-w32.dll")
+        libjbig2codec = cdll.LoadLibrary(os.path.join(baseDir, "./lib/bin/libjbig2codec-w32.dll"))
 else:
-    libjbig2codec = cdll.LoadLibrary("./libjbig2codec.so")
+    libjbig2codec = cdll.LoadLibrary(os.path.join(baseDir, "./libjbig2codec.so"))
 
 decode_jbig2data_c    = libjbig2codec.decode_jbig2data_c
 

--- a/jbigdec.py
+++ b/jbigdec.py
@@ -20,13 +20,14 @@ import struct
 import platform
 
 arch = platform.architecture()
+baseDir = os.path.dirname(__file__)
 if (arch[1] == 'WindowsPE'):
     if (arch[0] == '64bit'):
-        libjbigdec = cdll.LoadLibrary("./lib/bin/libjbigdec-w64.dll")
+        libjbigdec = cdll.LoadLibrary(os.path.join(baseDir, "./lib/bin/libjbigdec-w64.dll"))
     else:
-        libjbigdec = cdll.LoadLibrary("./lib/bin/libjbigdec-w32.dll")
+        libjbigdec = cdll.LoadLibrary(os.path.join(baseDir, "./lib/bin/libjbigdec-w32.dll"))
 else:
-    libjbigdec = cdll.LoadLibrary("./libjbigdec.so")
+    libjbigdec = cdll.LoadLibrary(os.path.join(baseDir, "./libjbigdec.so"))
 
 #SaveJbigAsBmp = libjbigdec.SaveJbigAsBmp
 #SaveJbigAsBmp.restype = None


### PR DESCRIPTION
If the command is called in other directory, the library file cannot be loaded.

So use the file path based on the `.py` file dir.