### PR TITLE
PyPDF2 3.x deprecation fix

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -155,9 +155,9 @@ def fnd_unuse_no(nos1, nos2):
 def make_dest(pdfw, pg):
     d = PDF.ArrayObject()
     try:
-        d.append(pdfw.getPage(pg).indirect_ref)
+        d.append(pdfw.pages[pg].indirect_ref)
     except AttributeError:
-        d.append(pdfw.getPage(pg).indirectRef)
+        d.append(pdfw.pages[pg].indirectRef)
     d.append(PDF.NameObject("/XYZ"))
     d.append(PDF.NullObject())
     d.append(PDF.NullObject())


### PR DESCRIPTION
This fixes the following error when the latest version of PyPDF2 is installed as a dependency:

```
Traceback (most recent call last):
  File "/Users/zizhengguo/software/caj2pdf/caj2pdf", line 52, in <module>
    caj.convert(args.output)
  File "/Users/zizhengguo/software/caj2pdf/cajparser.py", line 118, in convert
    self._convert_hn(dest)
  File "/Users/zizhengguo/software/caj2pdf/cajparser.py", line 462, in _convert_hn
    add_outlines(self.get_toc(), "pdf_toc.pdf", dest)
  File "/Users/zizhengguo/software/caj2pdf/utils.py", line 220, in add_outlines
    PDF.NameObject("/Dest"): make_dest(pdf_out, t["page"])
  File "/Users/zizhengguo/software/caj2pdf/utils.py", line 158, in make_dest
    d.append(pdfw.getPage(pg).indirect_ref)
  File "/opt/homebrew/lib/python3.10/site-packages/PyPDF2/_writer.py", line 394, in getPage
    deprecation_with_replacement("getPage", "writer.pages[page_number]", "3.0.0")
  File "/opt/homebrew/lib/python3.10/site-packages/PyPDF2/_utils.py", line 369, in deprecation_with_replacement
    deprecation(DEPR_MSG_HAPPENED.format(old_name, removed_in, new_name))
  File "/opt/homebrew/lib/python3.10/site-packages/PyPDF2/_utils.py", line 351, in deprecation
    raise DeprecationError(msg)
PyPDF2.errors.DeprecationError: getPage is deprecated and was removed in PyPDF2 3.0.0. Use writer.pages[page_number] instead.
```