### PR TITLE
Update link for PyPDF2

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ cc -Wall `pkg-config --cflags jbig2dec` -fPIC -shared -o libjbig2codec.so decode
 ### 环境和依赖
 
 - Python 3.3+
-- [PyPDF2](https://github.com/mstamy2/PyPDF2)
+- [PyPDF2](https://github.com/py-pdf/pypdf/tree/3.x)
 - [mutool](https://mupdf.com/index.html)
 
 除了Microsoft Windows：我们提供Microsoft Windows 32-bit/64-bit DLLs，HN 格式需要


### PR DESCRIPTION
By clicking the original link, page will be redirected into repo for PyPDF (without 2), possibly due to some merges. In its README, the suggestion command will install the latest version (4.x), which may cause confusion for the new users. So I replace the link. 